### PR TITLE
Remove sidebar menu icons

### DIFF
--- a/docs/_includes/_sidebar.html
+++ b/docs/_includes/_sidebar.html
@@ -61,7 +61,6 @@
       >
         {{item.title}}
       </a>
-      <div class="caret"></div>
       {% else %}
       <button
         type="button"
@@ -70,7 +69,6 @@
       >
         {{ item.title }}
       </button>
-      <div class="caret"></div>
       {% endif %}
 
       <div class="sub-menu">

--- a/docs/_sass/components/_header.scss
+++ b/docs/_sass/components/_header.scss
@@ -91,7 +91,11 @@
 
 @include bp(medium) {
   #site-header {
+    padding-top: 100px;
+    
     .header-flex {
+      flex-direction: column-reverse;
+
       .header-text {
         height: 300px;
         text-align: center;
@@ -107,7 +111,7 @@
       }
 
       .header-image {
-        display: none;
+        width: 80%;
       }
     }
   }

--- a/docs/_sass/components/_sidebar-menu.scss
+++ b/docs/_sass/components/_sidebar-menu.scss
@@ -72,36 +72,6 @@
       }
     }
 
-    .caret {
-      position: absolute;
-      right: ($base-point-grid * 3);
-      top: $base-point-grid * 3;
-      pointer-events: none;
-      transform-origin: 0% 75%;
-      height: 8px;
-      transition: transform 0.2s ease;
-    }
-
-    .caret::before {
-      content: "";
-      position: absolute;
-      top: 0;
-      left: 0;
-      border-left: 6px solid #bec3ca;
-      border-top: 6px solid transparent;
-      border-bottom: 6px solid transparent;
-    }
-
-    .caret::after {
-      content: "";
-      position: absolute;
-      left: 0;
-      top: 2px;
-      border-left: 4px solid #bec3ca;
-      border-top: 4px solid transparent;
-      border-bottom: 4px solid transparent;
-    }
-
     &.active {
       &::before {
         background-image: url("../img/sidebar-bullet-active.svg");
@@ -109,11 +79,6 @@
     }
 
     &.open {
-
-      .caret {
-        transform: rotateZ(90deg);
-      }
-
       .sub-menu {
         max-height: 1600px; // This will suffice for +20 entries in a submenu tops
 


### PR DESCRIPTION
Style modifications related to due to @israelperezglez comments:

- Removing menu direction icons from sidebar

![Captura de pantalla 2020-05-14 a las 21 49 02](https://user-images.githubusercontent.com/25897490/81979120-c40af000-962c-11ea-8c38-412798cc57e5.png)

- Keeping header imagen in small size view.
![Captura de pantalla 2020-05-14 a las 21 48 20](https://user-images.githubusercontent.com/25897490/81979134-c66d4a00-962c-11ea-8be6-2681f59dd282.png)
